### PR TITLE
fixed bug where extended_status 

### DIFF
--- a/extended_status-1.4.2.patch
+++ b/extended_status-1.4.2.patch
@@ -227,10 +227,10 @@ diff -ur nginx-1.4.2/src/event/ngx_event.c nginx-1.4.2_extended_status/src/event
 +
 +    ngx_num_workers = ccf->worker_processes;
 +
-+    workers = (worker_score *) (shared + 9 * cl);
++    workers = (worker_score *) (shared + 10 * cl);
 +    init_workers(workers);
 +
-+    conns = (conn_score *) (shared + 9 * cl + ccf->worker_processes * WORKER_SCORE_LEN);
++    conns = (conn_score *) (shared + 10 * cl + ccf->worker_processes * WORKER_SCORE_LEN);
 +
 +#endif
 +

--- a/extended_status-1.5.2.patch
+++ b/extended_status-1.5.2.patch
@@ -227,10 +227,10 @@ diff -ur nginx-1.5.2/src/event/ngx_event.c nginx-1.5.2_extended_status/src/event
 +
 +    ngx_num_workers = ccf->worker_processes;
 +
-+    workers = (worker_score *) (shared + 9 * cl);
++    workers = (worker_score *) (shared + 10 * cl);
 +    init_workers(workers);
 +
-+    conns = (conn_score *) (shared + 9 * cl + ccf->worker_processes * WORKER_SCORE_LEN);
++    conns = (conn_score *) (shared + 10 * cl + ccf->worker_processes * WORKER_SCORE_LEN);
 +
 +#endif
 +


### PR DESCRIPTION
extended_status wrote into area of memory that was owned by module stub and thus rewriting 'waiting requests' status variable value
