### PR TITLE
Bug fix! Add manipulation of conn_score on ngx_get_connection

### DIFF
--- a/README
+++ b/README
@@ -34,10 +34,10 @@ Example:
 
 -- How to patch Nginx core --
 For Nginx 0.8.54 (or 0.8.55),
-patch -p0 < extended_status-0.8.54.patch
+patch -p1 < extended_status-0.8.54.patch
 
 For Nginx 1.0.11,
-patch -p0 < extended_status-1.0.11.patch
+patch -p1 < extended_status-1.0.11.patch
 
 
 -- License --

--- a/extended_status-1.6.2.patch
+++ b/extended_status-1.6.2.patch
@@ -12,6 +12,23 @@ index 6b6e3b3..44dc5bc 100644
  
      /* disable warning: Win32 SOCKET is u_int while UNIX socket is int */
  
+@@ -866,8 +869,16 @@ ngx_get_connection(ngx_socket_t s, ngx_l
+     rev = c->read;
+     wev = c->write;
+ 
++#if (NGX_STAT_EXTENDED)
++    cs = c->cs;
++#endif
++
+     ngx_memzero(c, sizeof(ngx_connection_t));
+ 
++#if (NGX_STAT_EXTENDED)
++    c->cs = cs;
++#endif
++
+     c->read = rev;
+     c->write = wev;
+     c->fd = s;
 diff --git a/src/core/ngx_connection.h b/src/core/ngx_connection.h
 index ed14e60..21b6b38 100644
 --- a/src/core/ngx_connection.h


### PR DESCRIPTION
I'm using nginx 1.6.2. I've installed ngx_http_extended_status_module patch. However nginx dosen't work well with errors below.
```
$ tail -f logs/nginx/error.log
2015/01/21 11:41:55 [alert] 5167#0: worker process 5202 exited on signal 11
2015/01/21 11:42:00 [alert] 5167#0: worker process 5204 exited on signal 11
2015/01/21 11:42:05 [alert] 5167#0: worker process 5203 exited on signal 11
2015/01/21 11:42:10 [alert] 5167#0: worker process 5209 exited on signal 11
2015/01/21 11:42:14 [alert] 5167#0: worker process 5207 exited on signal 11
2015/01/21 11:42:15 [alert] 5167#0: worker process 5200 exited on signal 11
2015/01/21 11:42:16 [alert] 5167#0: worker process 5212 exited on signal 11
2015/01/21 11:42:17 [alert] 5167#0: worker process 5213 exited on signal 11
2015/01/21 11:42:17 [alert] 5167#0: worker process 5215 exited on signal 11
2015/01/21 11:42:20 [alert] 5167#0: worker process 5217 exited on signal 11
...
```