### PR TITLE
Fix 1.10.1.patch

### DIFF
--- a/extended_status-1.10.1.patch
+++ b/extended_status-1.10.1.patch
@@ -509,7 +509,7 @@ index 7d6cada..0f3913c 100644
 +        {
 +            if (0 != state[i].status)
 +            {
-+                ms = (ngx_msec_int_t) (state[i].response_sec * 1000 + state [i].response_msec);
++                ms = state[i].response_time;
 +                ms = (0 <= ms) ? ms : 0;
 +                break;
 +            }


### PR DESCRIPTION
avoid build errors:

``` bash
Last 15 lines from ~/Library/Logs/Homebrew/nginx-full/02.make:
                                                response_time
src/http/ngx_http_upstream.h:62:38: note: 'response_time' declared here
    ngx_msec_t                       response_time;
                                     ^
src/http/ngx_http_request.c:3436:81: error: no member named 'response_msec' in 'ngx_http_upstream_state_t'; did you mean 'response_time'?
                ms = (ngx_msec_int_t) (state[i].response_sec * 1000 + state [i].response_msec);
                                                                                ^~~~~~~~~~~~~
                                                                                response_time
src/http/ngx_http_upstream.h:62:38: note: 'response_time' declared here
    ngx_msec_t                       response_time;
```
